### PR TITLE
modify workflow to use nuget trusted publishing

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -69,13 +69,21 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ build-and-test ]
     environment: production
+    permissions:
+      id-token: write
+      contents: read
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '8.0.x'
+    - name: NuGet login (OIDC → temp API key)
+      uses: NuGet/login@v1
+      id: login
+      with:
+        user: ${{ secrets.NUGET_USER }}
     - name: Pack
       run: dotnet pack --configuration Release /p:Version='${{ needs.build-and-test.outputs.calculatedVersion }}' --include-symbols --output ${{ env.NuGetDirectory }}
     - name: Push
-      run: dotnet nuget push "${{ env.NuGetDirectory }}/*.nupkg" --api-key "${{ secrets.NUGETAPIKEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate
+      run: dotnet nuget push "${{ env.NuGetDirectory }}/*.nupkg" --api-key "${{ steps.login.outputs.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate


### PR DESCRIPTION
So that we don't have to rotate our API keys yearly, we can use nuget.org[ trusted publishing](https://learn.microsoft.com/en-gb/nuget/nuget-org/trusted-publishing) when we push our package instead of an API key